### PR TITLE
 Fix  #9: Add Mailcatcher Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,10 @@ group :development, :test do
   gem "debug", platforms: %i[ mri windows ]
 
   gem 'faker'
+
+  gem 'mailcatcher', '~> 0.2.4'
+
+  gem 'thin', '~> 1.8', '>= 1.8.2'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,16 @@ group :development, :test do
 
   gem 'mailcatcher', '~> 0.2.4'
 
+  # This gem shall be installed as without this we are getting
+  # compilation error like shown below
+  # An error occurred while installing thin (1.6.2), and Bundler cannot
+  # continue.
+  #
+  # In Gemfile:
+  #   mailcatcher was resolved to 0.2.4, which depends on
+  #     skinny was resolved to 0.2.4, which depends on
+  #       thin
+  # Hence as dependency with thin is needed we have to install it separately
   gem 'thin', '~> 1.8', '>= 1.8.2'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,16 +84,22 @@ GEM
     concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     crass (1.0.6)
+    daemons (1.4.1)
     date (3.3.4)
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
     drb (2.2.1)
     erubi (1.13.0)
+    eventmachine (1.2.7)
     faker (3.4.2)
       i18n (>= 1.8.11, < 2)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    haml (6.3.0)
+      temple (>= 0.8.2)
+      thor
+      tilt
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.0.1)
@@ -107,6 +113,7 @@ GEM
     jbuilder (2.12.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    json (2.7.2)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -115,10 +122,22 @@ GEM
       net-imap
       net-pop
       net-smtp
+    mailcatcher (0.2.4)
+      eventmachine
+      haml
+      i18n
+      json
+      mail
+      sinatra
+      skinny (>= 0.1.2)
+      sqlite3-ruby
+      thin
     marcel (1.0.4)
     mini_mime (1.1.5)
     minitest (5.24.1)
     msgpack (1.7.2)
+    mustermann (3.0.2)
+      ruby2_keywords (~> 0.0.1)
     mutex_m (0.2.0)
     net-imap (0.4.14)
       date
@@ -148,14 +167,17 @@ GEM
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.1.7)
-    rack-session (2.0.0)
-      rack (>= 3.0.0)
+    rack (2.2.9)
+    rack-protection (3.2.0)
+      base64 (>= 0.1.0)
+      rack (~> 2.2, >= 2.2.4)
+    rack-session (1.0.2)
+      rack (< 3)
     rack-test (2.1.0)
       rack (>= 1.3)
-    rackup (2.1.0)
-      rack (>= 3)
-      webrick (~> 1.8)
+    rackup (1.0.0)
+      rack (< 3)
+      webrick
     rails (7.1.3.4)
       actioncable (= 7.1.3.4)
       actionmailbox (= 7.1.3.4)
@@ -194,6 +216,15 @@ GEM
       connection_pool
     reline (0.5.9)
       io-console (~> 0.5)
+    ruby2_keywords (0.0.5)
+    sinatra (3.2.0)
+      mustermann (~> 3.0)
+      rack (~> 2.2, >= 2.2.4)
+      rack-protection (= 3.2.0)
+      tilt (~> 2.0)
+    skinny (0.2.2)
+      eventmachine (~> 1.0)
+      thin
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -201,10 +232,24 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    sqlite3 (2.0.3-aarch64-linux-gnu)
+    sqlite3 (2.0.3-arm-linux-gnu)
+    sqlite3 (2.0.3-arm64-darwin)
+    sqlite3 (2.0.3-x86-linux-gnu)
+    sqlite3 (2.0.3-x86_64-darwin)
+    sqlite3 (2.0.3-x86_64-linux-gnu)
+    sqlite3-ruby (1.3.3)
+      sqlite3 (>= 1.3.3)
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
     stringio (3.1.1)
+    temple (0.10.3)
+    thin (1.8.2)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
     thor (1.3.1)
+    tilt (2.4.0)
     timeout (0.4.1)
     turbo-rails (2.0.6)
       actionpack (>= 6.0.0)
@@ -237,12 +282,14 @@ DEPENDENCIES
   faker
   importmap-rails
   jbuilder
+  mailcatcher (~> 0.2.4)
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)
   redis (>= 4.0.1)
   sprockets-rails
   stimulus-rails
+  thin (~> 1.8, >= 1.8.2)
   turbo-rails
   tzinfo-data
   web-console

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,4 +73,11 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  # Use mailcatcher for email delivery in development
+  # Run `mailcatcher` in the terminal to start the SMTP server and web interface
+  # Access the web interface at http://127.0.0.1:1080 to view captured emails
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { address: '127.0.0.1', port: 1025 }
+
 end


### PR DESCRIPTION
1. Added two gems namely a. Mail catcher b. Thin (added separately as bundle install with only mail catcher is showing compiler errors)
2. Gem file lock file is updated with the newer versions of the dependencies

<!-- Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- Title include "WIP" if work is in progress.

-->

Resolves #9 

### Description
Mailcatcher gem and also thin which is a dependency for mail catcher

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Feature

### How to test this PR?

Bundle install should install mail catcher gem and also other dependencies
