### PR TITLE
Fixes #31 feature request: Add jwt token based authentication for signup and logout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,4 +54,4 @@ gem 'rack-cors'
 
 gem 'devise', '~> 4.9'
 gem 'jsonapi-serializer'
-
+gem 'devise-jwt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,19 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-jwt (0.12.1)
+      devise (~> 4.0)
+      warden-jwt_auth (~> 0.10)
     drb (2.2.1)
+    dry-auto_inject (1.0.1)
+      dry-core (~> 1.0)
+      zeitwerk (~> 2.6)
+    dry-configurable (1.2.0)
+      dry-core (~> 1.0, < 2)
+      zeitwerk (~> 2.6)
+    dry-core (1.0.1)
+      concurrent-ruby (~> 1.0)
+      zeitwerk (~> 2.6)
     erubi (1.13.0)
     eventmachine (1.2.7)
     faker (3.4.2)
@@ -116,6 +128,8 @@ GEM
     json (2.7.2)
     jsonapi-serializer (2.2.0)
       activesupport (>= 4.2)
+    jwt (2.8.2)
+      base64
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -246,6 +260,11 @@ GEM
       concurrent-ruby (~> 1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
+    warden-jwt_auth (0.10.0)
+      dry-auto_inject (>= 0.8, < 2)
+      dry-configurable (>= 0.13, < 2)
+      jwt (~> 2.1)
+      warden (~> 1.2)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -264,6 +283,7 @@ DEPENDENCIES
   bootsnap
   debug
   devise (~> 4.9)
+  devise-jwt
   faker
   jsonapi-serializer
   mailcatcher (~> 0.2.4)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
+  include Devise::JWT::RevocationStrategies::JTIMatcher
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable, :confirmable
+         :recoverable, :rememberable, :validatable, :confirmable,
+         :jwt_authenticatable, jwt_revocation_strategy: self
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -321,6 +321,6 @@ Devise.setup do |config|
     jwt.revocation_requests = [
       ['DELETE', %r{^/logout$}]
     ]
-    jwt.expiration_time = 30.minutes.to_i
+    jwt.expiration_time = 1.month.to_i
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -310,4 +310,17 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
+
+  # ==> Configuration for devise-jwt
+
+  config.jwt do |jwt|
+    jwt.secret = Rails.application.credentials.fetch(:secret_key_base)
+    jwt.dispatch_requests = [
+      ['POST', %r{^/login$}]
+    ]
+    jwt.revocation_requests = [
+      ['DELETE', %r{^/logout$}]
+    ]
+    jwt.expiration_time = 30.minutes.to_i
+  end
 end

--- a/db/migrate/20240827052912_add_jti_to_users.rb
+++ b/db/migrate/20240827052912_add_jti_to_users.rb
@@ -1,0 +1,6 @@
+class AddJtiToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :jti, :string, null: false
+    add_index :users, :jti, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_23_132442) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_27_052912) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -26,8 +26,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_23_132442) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.string "jti", null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["jti"], name: "index_users_on_jti", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 


### PR DESCRIPTION
1. Gem file is updated with new gem about devise-jwt
2. devise.rb is updated with configuration related to JWT
3. Migration file 20240827052912_add_jti_to_users.rb is added about jti column to users model
4. schema.rb is updated with new columns
5. user.rb is updated with jwt and also revocation strategies

Resolves #31 

### Description

1. Addition of JWT to the login and providing JWT for the logout

### Type of change

- [ ] Feature

### How to test this PR?

**Signup**
![CleanShot 2024-08-27 at 12 22 37](https://github.com/user-attachments/assets/301aedec-3b8b-4d2b-b458-d8d3ef63a166)

**LogIn**
![CleanShot 2024-08-27 at 12 28 01](https://github.com/user-attachments/assets/0b4da9f7-9f92-4c9b-91cd-8a1fe3cbe919)


**Accessing JWT from headers **

![CleanShot 2024-08-27 at 12 27 05](https://github.com/user-attachments/assets/6c75c74e-6e52-4914-b5da-da8a4ba3bdb1)

**Logout**
Attaching the bearer token to the delete request along with the user data should destroy session and display the log out successfully as response

![CleanShot 2024-08-27 at 12 30 06](https://github.com/user-attachments/assets/cdb09979-5d78-46b9-99da-3ad2249aad72)
