### PR TITLE
Fixes #37 Creation of Degree Model

### DIFF
--- a/app/models/degree.rb
+++ b/app/models/degree.rb
@@ -1,0 +1,2 @@
+class Degree < ApplicationRecord
+end

--- a/db/migrate/20240906172152_create_degrees.rb
+++ b/db/migrate/20240906172152_create_degrees.rb
@@ -1,0 +1,8 @@
+class CreateDegrees < ActiveRecord::Migration[7.1]
+  def change
+    create_table :degrees do |t|
+      t.string :name
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_06_044059) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_06_172152) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_06_044059) do
     t.string "state"
     t.string "country"
     t.string "pin_code"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "degrees", force: :cascade do |t|
+    t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
1. Degree model with name column
2. Schema and migration file related to degree model

Resolves #37 

### Description

Creation of degree model with only column name only

### Type of change

- [ ] Feature


### How to test this PR?

1. After running rails migration successfully, below can be checked in db through rails console

irb(main):001> Degree.column_names
=> ["id", "name", "created_at", "updated_at"]
