### PR TITLE
Fixes #38 Addition of registration council model

### DIFF
--- a/app/models/registration_council.rb
+++ b/app/models/registration_council.rb
@@ -1,0 +1,2 @@
+class RegistrationCouncil < ApplicationRecord
+end

--- a/db/migrate/20240906183131_create_registration_councils.rb
+++ b/db/migrate/20240906183131_create_registration_councils.rb
@@ -1,0 +1,8 @@
+class CreateRegistrationCouncils < ActiveRecord::Migration[7.1]
+  def change
+    create_table :registration_councils do |t|
+      t.string :name
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_06_172152) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_06_183131) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -26,6 +26,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_06_172152) do
   end
 
   create_table "degrees", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "registration_councils", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
1. registration_council.rb model with name as column
2. schema.rb updated with newer table details
3. Migration file for registration council

Resolves #38 

### Description
1. Creation of registration council model with migration and schema changes

### Type of change

- [ ] Feature


### How to test this PR?

1. Run migration and check whether table is created by running rails c, followed by below command that shows table with column names

irb(main):001> RegistrationCouncil.column_names
=> ["id", "name", "created_at", "updated_at"]
