### PR TITLE
Fixes#️70 Add Establishments API with CRUD operations and filtering capabilities.

### DIFF
--- a/app/controllers/api/v1/establishments_controller.rb
+++ b/app/controllers/api/v1/establishments_controller.rb
@@ -1,0 +1,87 @@
+class Api::V1::EstablishmentsController < ApplicationController
+  before_action :authenticate_user!, only: %i[create update destroy]
+  before_action :set_doctor_profile, only: %i[create update destroy]
+  before_action :set_establishment, only: %i[update destroy]
+
+  def index
+    establishments = filter_establishments
+    if establishments.exists?
+      render_success('Establishments found successfully.', establishments)
+    else
+      render_error('No establishments match the given criteria.', :not_found)
+    end
+  end
+
+  def show
+    establishment = Establishment.find_by(id: params[:id])
+    if establishment
+      render_success('Establishment found successfully.', establishment)
+    else
+      render_error('Establishment not found.', :not_found)
+    end
+  end
+
+  def create
+    establishment = @doctor_profile.establishments.create(establishment_params)
+    if establishment.persisted?
+      render_success('Establishment created successfully.', establishment)
+    else
+      render_error("Establishment could not be created. #{establishment.errors.full_messages.to_sentence}")
+    end
+  end
+
+  def update
+    if @establishment.update(establishment_params)
+      render_success('Establishment updated successfully.', @establishment)
+    else
+      render_error("Establishment could not be updated. #{@establishment.errors.full_messages.to_sentence}")
+    end
+  end
+
+  def destroy
+    @establishment.destroy
+    render_success('Establishment deleted successfully.')
+  end
+
+  private
+
+  def establishment_params
+    params.require(:establishment).permit(:name, :latitude, :longitude, :maps_location, address_attributes: [:address_line_1, :address_line_2, :city, :state, :country, :pin_code])
+  end
+
+  def set_doctor_profile
+    @doctor_profile = current_user&.doctor_profile
+    return render_error('User is not authorized.', :forbidden) unless @doctor_profile
+  end
+
+  def set_establishment
+    @establishment = @doctor_profile.establishments.find_by(id: params[:id])
+    render_error('Establishment not found.', :not_found) unless @establishment
+  end
+
+  def filter_establishments
+    filter_params = params.permit(:name, :city, :state, :country, :pin_code, :doctor_profile_id)
+
+    scope = Establishment.all
+    scope = scope.joins(:address) if address_filter_params_present?(filter_params)
+    scope = scope.joins(:doctor_profiles) if filter_params[:doctor_profile_id].present?
+
+    scope = scope.where(name: filter_params[:name]) if filter_params[:name].present?
+    scope = scope.where(addresses: { city: filter_params[:city], state: filter_params[:state], country: filter_params[:country], pin_code: filter_params[:pin_code] }.compact) if address_filter_params_present?(filter_params)
+    scope = scope.where(doctor_profiles: { id: filter_params[:doctor_profile_id] }) if filter_params[:doctor_profile_id].present?
+
+    scope
+  end
+
+  def address_filter_params_present?(filter_params)
+    filter_params[:city].present? || filter_params[:state].present? || filter_params[:country].present? || filter_params[:pin_code].present?
+  end
+
+  def render_success(message, data = nil)
+    render json: { message: message, data: data }.compact, status: :ok
+  end
+
+  def render_error(message, status = :unprocessable_entity)
+    render json: { message: message }, status: status
+  end
+end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,2 +1,3 @@
 class Address < ApplicationRecord
+  validates :address_line_1, :city, :state, :country, :pin_code, presence: true
 end

--- a/app/models/doctor_profile.rb
+++ b/app/models/doctor_profile.rb
@@ -3,4 +3,6 @@ class DoctorProfile < ApplicationRecord
   belongs_to :degree, optional: true
   belongs_to :institute, optional: true
   has_one :user
+  has_many :doctor_establishments, dependent: :destroy
+  has_many :establishments, through: :doctor_establishments
 end

--- a/app/models/establishment.rb
+++ b/app/models/establishment.rb
@@ -1,2 +1,9 @@
 class Establishment < ApplicationRecord
+  belongs_to :address
+  has_many :doctor_establishments, dependent: :destroy
+  has_many :doctor_profiles, through: :doctor_establishments
+
+  validates :name, presence: true
+
+  accepts_nested_attributes_for :address, update_only: true
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -11,6 +11,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
 
     resource "*",
       headers: :any,
-      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+      methods: [:get, :post, :put, :patch, :delete, :options, :head],
+      expose: ["Authorization"]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,11 @@ Rails.application.routes.draw do
     registration: 'signup'
   }
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      resources :establishments
+    end
+  end
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.


### PR DESCRIPTION
Resolves #70 

### Description

This PR adds the EstablishmentsController API to manage establishments with basic CRUD operations and filtering by `name`, `city`, `state`, `country`, `pin_code`, `doctor_profile_id`. It also includes model associations.

### Type of change

- [x] Feature

### How to test this PR?

Test CRUD actions (create, read, update, delete) on establishments.
Use filters to search establishments by filter parameters(`name`, `city`, `state`, `country`, `pin_code`, `doctor_profile_id`).
Import the included Postman collection to test all the API endpoints.

[klinicon-backend.postman_collection.json](https://github.com/user-attachments/files/17706665/klinicon-backend.postman_collection.json)

